### PR TITLE
support accepting a function in the errorMsg option

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,29 +80,7 @@ cy.getCookie('token') // will not be retried
 
 ### TypeScript
 
-If you use TypeScript you can define the `checkFunction` returning type too. Here some examples with all the combinations of promises and chainable functions
-
-```typescript
-cy.waitUntil(() => true);
-cy.waitUntil<boolean>(() => true);
-cy.waitUntil<string>(() => true); // Error
-
-cy.waitUntil(() => Promise.resolve(true) );
-cy.waitUntil<boolean>(() => Promise.resolve(true) );
-cy.waitUntil<string>(() => Promise.resolve(true) );  // Error
-
-cy.waitUntil(() => cy.wrap(true) );
-cy.waitUntil<boolean>(() => cy.wrap(true) );
-cy.waitUntil<string>(() => cy.wrap(true) );  // Error
-
-cy.waitUntil(() => cy.wrap(true).then(result => result) );
-cy.waitUntil<boolean>(() => cy.wrap(true).then(result => result) );
-cy.waitUntil<string>(() => cy.wrap(true).then(result => result) );  // Error
-
-cy.waitUntil(() => cy.wrap(true).then(result => Promise.resolve(result)) );
-cy.waitUntil<boolean>(() => cy.wrap(true).then(result => Promise.resolve(result)) );
-cy.waitUntil<string>(() => cy.wrap(true).then(result => Promise.resolve(result)) );  // Error
-```
+If you use TypeScript you can define the `checkFunction` returning type too. Take a look at the [plugin.spec.ts](./cypress/types/plugin.spec.ts) file to read about the `cy.waitUntil` signature.
 
 #### IMPORTANT:
 1. Remember to add `cypress-wait-until` to the `cypress/tsconfig.json` file
@@ -137,17 +115,17 @@ A function that must return a truthy value when the wait is over.
 
 Pass in an options object to change the default behavior of `cy.waitUntil()`.
 
-| Option               | Default                | Description                                                                                                                                               |
-| -------------------- | ---------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `errorMsg`           | `"Timed out retrying"` | The error message to write.                                                                                                                               |
-| `timeout`            | `5000`                 | Time to wait for the `checkFunction` to return a truthy value before throwing an error.                                                                   |
-| `interval`           | `200`                  | Time to wait between the `checkFunction` invocations.                                                                                                     |
-| `description`        | `"waitUntil"`          | The name logged into the Cypress Test Runner.                                                                                                             |
-| `logger`             | `Cypress.log`          | A custom logger in place of the default [Cypress.log](https://docs.cypress.io/api/cypress-api/cypress-log.html). It's useful just for debugging purposes. |
-| `log`                | `true`                 | Enable/disable logging.                                                                                                                                   |
-| `customMessage`      | `undefined`            | String logged after the `options.description`.                                                                                                            |
-| `verbose`            | `false`                | If every single check result must be logged.                                                                                                              |
-| `customCheckMessage` | `undefined`            | Like `customMessage`, but used for every single check. Useless if `verbose` is not set to `true`.                                                         |
+| Option               | Type                   | Default                | Description                                                                                                                                               |
+| -------------------- | ---------------------- | ---------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `errorMsg`           | `string` \| `function` | `"Timed out retrying"` | The error message to write. If it's a function, it will receive the last result and the options passed to `cy.waitUntil`                                  |
+| `timeout`            | `number`               | `5000`                 | Time to wait for the `checkFunction` to return a truthy value before throwing an error.                                                                   |
+| `interval`           | `number`               | `200`                  | Time to wait between the `checkFunction` invocations.                                                                                                     |
+| `description`        | `string`               | `"waitUntil"`          | The name logged into the Cypress Test Runner.                                                                                                             |
+| `logger`             | `function`             | `Cypress.log`          | A custom logger in place of the default [Cypress.log](https://docs.cypress.io/api/cypress-api/cypress-log.html). It's useful just for debugging purposes. |
+| `log`                | `boolean`              | `true`                 | Enable/disable logging.                                                                                                                                   |
+| `customMessage`      | `string`               | `undefined`            | String logged after the `options.description`.                                                                                                            |
+| `verbose`            | `boolean`              | `false`                | If every single check result must be logged.                                                                                                              |
+| `customCheckMessage` | `string`               | `undefined`            | Like `customMessage`, but used for every single check. Useless if `verbose` is not set to `true`.                                                         |
 
 Log options are a lot, take a look at the next screenshot to understand how they are printed
 

--- a/cypress/integration/plugin.spec.js
+++ b/cypress/integration/plugin.spec.js
@@ -153,6 +153,26 @@ context("Cypress Wait Until", () => {
     cy.waitUntil(checkFunction, { errorMsg: "Custom error message" });
   });
 
+  it("Should accept a custom error message that is a function", () => {
+    const COOKIE_NAME = "unknwon-cookie";
+    const EXPECTED_COOKIE_VALUE = "Set";
+    let dynamicValue = "before";
+
+    cy.once("fail", (err) => {
+      expect(err.message).to.be.equal("Custom error message - after");
+    });
+
+    const checkFunction = () =>
+      cy.getCookie(COOKIE_NAME).then((cookieValue) => {
+        dynamicValue = "after";
+        return cookieValue && cookieValue.value === EXPECTED_COOKIE_VALUE;
+      });
+
+    cy.waitUntil(checkFunction, {
+      errorMsg: () => `Custom error message - ${dynamicValue}`,
+    });
+  });
+
   it("Should pass the result to the next command", () => {
     const result = 10;
 

--- a/cypress/integration/plugin.spec.js
+++ b/cypress/integration/plugin.spec.js
@@ -1,360 +1,390 @@
 /// <reference types="Cypress" />
 
-context("Cypress Wait Until", () => {
+context('Cypress Wait Until', () => {
   beforeEach(() => {
-    cy.visit("http://localhost:5000/");
-  });
+    cy.visit('http://localhost:5000/')
+  })
 
-  it("Should work with an immediately-satisfied condition", () => {
-    const COOKIE_NAME = "immediate-cookie";
-    const EXPECTED_COOKIE_VALUE = "Set";
-    cy.get("#" + COOKIE_NAME).click();
+  it('Should work with an immediately-satisfied condition', () => {
+    const COOKIE_NAME = 'immediate-cookie'
+    const EXPECTED_COOKIE_VALUE = 'Set'
+    cy.get('#' + COOKIE_NAME).click()
 
     const checkFunction = () =>
       cy
         .getCookie(COOKIE_NAME)
-        .then(cookieValue => cookieValue && cookieValue.value === EXPECTED_COOKIE_VALUE);
+        .then((cookieValue) => cookieValue && cookieValue.value === EXPECTED_COOKIE_VALUE)
 
-    cy.waitUntil(checkFunction);
+    cy.waitUntil(checkFunction)
 
-    cy.getCookie(COOKIE_NAME).then(cookieValue =>
+    cy.getCookie(COOKIE_NAME).then((cookieValue) =>
       expect(cookieValue.value).to.be.equal(EXPECTED_COOKIE_VALUE)
-    );
-  });
+    )
+  })
 
-  it("Should work with a condition satisfied after a random delay", () => {
-    const COOKIE_NAME = "after-a-while-cookie";
-    const EXPECTED_COOKIE_VALUE = "Set";
-    cy.get("#" + COOKIE_NAME).click();
+  it('Should work with a condition satisfied after a random delay', () => {
+    const COOKIE_NAME = 'after-a-while-cookie'
+    const EXPECTED_COOKIE_VALUE = 'Set'
+    cy.get('#' + COOKIE_NAME).click()
 
     const checkFunction = () =>
       cy
         .getCookie(COOKIE_NAME)
-        .then(cookieValue => cookieValue && cookieValue.value === EXPECTED_COOKIE_VALUE);
+        .then((cookieValue) => cookieValue && cookieValue.value === EXPECTED_COOKIE_VALUE)
 
     cy.waitUntil(checkFunction).then(() => {
-      cy.getCookie(COOKIE_NAME).then(cookieValue =>
+      cy.getCookie(COOKIE_NAME).then((cookieValue) =>
         expect(cookieValue.value).to.be.equal(EXPECTED_COOKIE_VALUE)
-      );
-    });
-  });
+      )
+    })
+  })
 
-  it("Should apply options correctly", () => {
-    const COOKIE_NAME = "after-a-while-cookie";
-    const EXPECTED_COOKIE_VALUE = "Set";
+  it('Should apply options correctly', () => {
+    const COOKIE_NAME = 'after-a-while-cookie'
+    const EXPECTED_COOKIE_VALUE = 'Set'
 
-    cy.once("fail", err => {
-      expect(err.message).to.be.equal("Timed out retrying");
-    });
+    cy.once('fail', (err) => {
+      expect(err.message).to.be.equal('Timed out retrying')
+    })
 
-    cy.get("#" + COOKIE_NAME).click();
+    cy.get('#' + COOKIE_NAME).click()
 
     const checkFunction = () =>
       cy
         .getCookie(COOKIE_NAME)
-        .then(cookieValue => cookieValue && cookieValue.value === EXPECTED_COOKIE_VALUE);
+        .then((cookieValue) => cookieValue && cookieValue.value === EXPECTED_COOKIE_VALUE)
 
     cy.waitUntil(checkFunction, {
       interval: 100,
-      timeout: 900
-    });
-  });
+      timeout: 900,
+    })
+  })
 
-  it("Should log a custom logging description", () => {
-    const COOKIE_NAME = "after-a-while-cookie";
-    const EXPECTED_COOKIE_VALUE = "Set";
+  it('Should log a custom logging description', () => {
+    const COOKIE_NAME = 'after-a-while-cookie'
+    const EXPECTED_COOKIE_VALUE = 'Set'
 
-    cy.once("fail", err => {
-      expect(err.message).to.be.equal("Timed out retrying");
-    });
+    cy.once('fail', (err) => {
+      expect(err.message).to.be.equal('Timed out retrying')
+    })
 
-    cy.get("#" + COOKIE_NAME).click();
+    cy.get('#' + COOKIE_NAME).click()
 
     const checkFunction = () =>
       cy
         .getCookie(COOKIE_NAME)
-        .then(cookieValue => cookieValue && cookieValue.value === EXPECTED_COOKIE_VALUE);
+        .then((cookieValue) => cookieValue && cookieValue.value === EXPECTED_COOKIE_VALUE)
 
     cy.waitUntil(checkFunction, {
       interval: 100,
-      timeout: 900
-    });
-  });
+      timeout: 900,
+    })
+  })
 
-  it("Should check value equality check", () => {
-    const COOKIE_NAME = "change-after-a-while-cookie";
-    const EXPECTED_COOKIE_VALUE = "7";
-    cy.get("#" + COOKIE_NAME).click();
+  it('Should check value equality check', () => {
+    const COOKIE_NAME = 'change-after-a-while-cookie'
+    const EXPECTED_COOKIE_VALUE = '7'
+    cy.get('#' + COOKIE_NAME).click()
 
     const checkFunction = () =>
       cy
         .getCookie(COOKIE_NAME)
-        .then(cookieValue => cookieValue && cookieValue.value === EXPECTED_COOKIE_VALUE);
+        .then((cookieValue) => cookieValue && cookieValue.value === EXPECTED_COOKIE_VALUE)
 
-    cy.waitUntil(checkFunction);
+    cy.waitUntil(checkFunction)
 
-    cy.getCookie(COOKIE_NAME).then(cookieValue =>
+    cy.getCookie(COOKIE_NAME).then((cookieValue) =>
       expect(cookieValue.value).to.be.equal(EXPECTED_COOKIE_VALUE)
-    );
-  });
+    )
+  })
 
-  it("Should make the test fail with an unsatisfied condition", () => {
-    const COOKIE_NAME = "unknwon-cookie";
-    const EXPECTED_COOKIE_VALUE = "Set";
+  it('Should make the test fail with an unsatisfied condition', () => {
+    const COOKIE_NAME = 'unknwon-cookie'
+    const EXPECTED_COOKIE_VALUE = 'Set'
 
-    cy.once("fail", err => {
-      expect(err.message).to.be.equal("Timed out retrying");
-    });
+    cy.once('fail', (err) => {
+      expect(err.message).to.be.equal('Timed out retrying')
+    })
 
     const checkFunction = () =>
       cy
         .getCookie(COOKIE_NAME)
-        .then(cookieValue => cookieValue && cookieValue.value === EXPECTED_COOKIE_VALUE);
+        .then((cookieValue) => cookieValue && cookieValue.value === EXPECTED_COOKIE_VALUE)
 
-    cy.waitUntil(checkFunction);
-  });
+    cy.waitUntil(checkFunction)
+  })
 
-  it("Should work sync", () => {
-    const checkFunction = () => true;
+  it('Should work sync', () => {
+    const checkFunction = () => true
 
-    cy.waitUntil(checkFunction);
-  });
+    cy.waitUntil(checkFunction)
+  })
 
-  it("Should work sync with retries", () => {
-    let n = 4;
+  it('Should work sync with retries', () => {
+    let n = 4
     const checkFunction = () => {
-      n--;
-      return n < 0;
-    };
+      n--
+      return n < 0
+    }
 
-    cy.waitUntil(checkFunction);
-  });
+    cy.waitUntil(checkFunction)
+  })
 
-  it("`checkFunction` should be a function", () => {
-    const ERROR_MESSAGE = "`checkFunction` parameter should be a function. Found: true";
+  it('`checkFunction` should be a function', () => {
+    const ERROR_MESSAGE = '`checkFunction` parameter should be a function. Found: true'
 
-    cy.once("fail", err => expect(err.message).to.be.equal(ERROR_MESSAGE));
-    cy.waitUntil(true);
-  });
+    cy.once('fail', (err) => expect(err.message).to.be.equal(ERROR_MESSAGE))
+    cy.waitUntil(true)
+  })
 
-  it("Should accept a custom error message", () => {
-    const COOKIE_NAME = "unknwon-cookie";
-    const EXPECTED_COOKIE_VALUE = "Set";
+  it('Should accept a custom error message', () => {
+    const COOKIE_NAME = 'unknwon-cookie'
+    const EXPECTED_COOKIE_VALUE = 'Set'
 
-    cy.once("fail", err => {
-      expect(err.message).to.be.equal("Custom error message");
-    });
+    cy.once('fail', (err) => {
+      expect(err.message).to.be.equal('Custom error message')
+    })
 
     const checkFunction = () =>
       cy
         .getCookie(COOKIE_NAME)
-        .then(cookieValue => cookieValue && cookieValue.value === EXPECTED_COOKIE_VALUE);
+        .then((cookieValue) => cookieValue && cookieValue.value === EXPECTED_COOKIE_VALUE)
 
-    cy.waitUntil(checkFunction, { errorMsg: "Custom error message" });
-  });
+    cy.waitUntil(checkFunction, { errorMsg: 'Custom error message' })
+  })
 
-  it("Should accept a custom error message that is a function", () => {
-    const COOKIE_NAME = "unknwon-cookie";
-    const EXPECTED_COOKIE_VALUE = "Set";
-    let dynamicValue = "before";
+  it('Should accept a custom error message that is a function', () => {
+    const COOKIE_NAME = 'unknwon-cookie'
+    const EXPECTED_COOKIE_VALUE = 'Set'
+    let dynamicValue = 'before'
 
-    cy.once("fail", (err) => {
-      expect(err.message).to.be.equal("Custom error message - after");
-    });
+    cy.once('fail', (err) => {
+      expect(err.message).to.be.equal('Custom error message - after')
+    })
 
     const checkFunction = () =>
       cy.getCookie(COOKIE_NAME).then((cookieValue) => {
-        dynamicValue = "after";
-        return cookieValue && cookieValue.value === EXPECTED_COOKIE_VALUE;
-      });
+        dynamicValue = 'after'
+        return cookieValue && cookieValue.value === EXPECTED_COOKIE_VALUE
+      })
 
     cy.waitUntil(checkFunction, {
       errorMsg: () => `Custom error message - ${dynamicValue}`,
-    });
-  });
+    })
+  })
 
-  it("Should pass the result to the next command", () => {
-    const result = 10;
+  it('Should pass the options passed to the plugin to the custom error message function', () => {
+    const options = {
+      timeout: 100,
+      interval: 50,
+    }
+    const errorMsg = (result, pluginOptions) => {
+      expect(result).to.eq(0)
+      expect(pluginOptions).to.deep.eq({
+        ...options,
+        description: 'waitUntil',
+        log: true,
+        customMessage: [options],
+        logger: Cypress.log,
+        verbose: false,
+        customCheckMessage: undefined,
+      })
+      return 'Params expectations ok'
+    }
+    options.errorMsg = errorMsg
 
-    const checkFunction = () => result;
-    const asyncCheckFunction = () => Promise.resolve(result);
-    const chainableCheckFunction = () => cy.wrap(result).then(wrappedResult => wrappedResult);
+    let lastResult = 1
+    const checkFunction = () => {
+      lastResult = 0
+      return lastResult
+    }
 
-    cy.waitUntil(checkFunction).should("eq", result);
-    cy.waitUntil(asyncCheckFunction).should("eq", result);
-    cy.waitUntil(chainableCheckFunction).should("eq", result);
-  });
+    cy.once('fail', (err) => {
+      expect(err.message).to.be.equal('Params expectations ok')
+    })
+    cy.waitUntil(checkFunction, options)
+  })
 
-  it("Should wait between every check", () => {
-    const interval = 100;
-    let previousTimestamp;
+  it('Should pass the result to the next command', () => {
+    const result = 10
+
+    const checkFunction = () => result
+    const asyncCheckFunction = () => Promise.resolve(result)
+    const chainableCheckFunction = () => cy.wrap(result).then((wrappedResult) => wrappedResult)
+
+    cy.waitUntil(checkFunction).should('eq', result)
+    cy.waitUntil(asyncCheckFunction).should('eq', result)
+    cy.waitUntil(chainableCheckFunction).should('eq', result)
+  })
+
+  it('Should wait between every check', () => {
+    const interval = 100
+    let previousTimestamp
 
     const checkFunction = () => {
-      const previousTimestampBackup = previousTimestamp;
-      const newTimestamp = Date.now();
-      previousTimestamp = newTimestamp;
+      const previousTimestampBackup = previousTimestamp
+      const newTimestamp = Date.now()
+      previousTimestamp = newTimestamp
       if (previousTimestampBackup) {
-        const diff = newTimestamp - previousTimestampBackup;
-        return diff >= interval;
+        const diff = newTimestamp - previousTimestampBackup
+        return diff >= interval
       }
-      return false;
-    };
+      return false
+    }
 
-    const asyncCheckFunction = () => Promise.resolve(checkFunction());
-    const chainableCheckFunction = () => cy.wrap().then(() => checkFunction());
+    const asyncCheckFunction = () => Promise.resolve(checkFunction())
+    const chainableCheckFunction = () => cy.wrap().then(() => checkFunction())
 
-    cy.log("Sync function");
-    cy.waitUntil(checkFunction, { interval });
-    cy.log("Async function");
-    cy.waitUntil(asyncCheckFunction, { interval });
-    cy.log("Chainable function");
-    cy.waitUntil(chainableCheckFunction, { interval });
-  });
+    cy.log('Sync function')
+    cy.waitUntil(checkFunction, { interval })
+    cy.log('Async function')
+    cy.waitUntil(asyncCheckFunction, { interval })
+    cy.log('Chainable function')
+    cy.waitUntil(chainableCheckFunction, { interval })
+  })
 
-  it("Should be chainable", () => {
-    const result = 10;
-    const checkFunction = () => result;
-    const checkFunctionWithSubject = subject => subject;
+  it('Should be chainable', () => {
+    const result = 10
+    const checkFunction = () => result
+    const checkFunctionWithSubject = (subject) => subject
 
-    cy.waitUntil(checkFunction).should("eq", result);
+    cy.waitUntil(checkFunction).should('eq', result)
 
-    cy.wrap(result)
-      .waitUntil(checkFunctionWithSubject)
-      .should("eq", result);
-  });
+    cy.wrap(result).waitUntil(checkFunctionWithSubject).should('eq', result)
+  })
 
-  it("Should leverage Cypress.log", () => {
-    const checkFunction = () => true;
+  it('Should leverage Cypress.log', () => {
+    const checkFunction = () => true
 
     const logger = {
-      log: (...params) => Cypress.log(...params)
-    };
-    const spy = cy.spy(logger, "log");
+      log: (...params) => Cypress.log(...params),
+    }
+    const spy = cy.spy(logger, 'log')
 
     cy.waitUntil(checkFunction, { logger: logger.log }).then(() => {
-      expect(spy).to.have.been.called;
-      const lastCallArgs = spy.lastCall.args[0];
-      expect(lastCallArgs).deep.include({ name: "waitUntil" });
-    });
-  });
+      expect(spy).to.have.been.called
+      const lastCallArgs = spy.lastCall.args[0]
+      expect(lastCallArgs).deep.include({ name: 'waitUntil' })
+    })
+  })
 
-  it("Should accept a custom log description", () => {
-    const checkFunction = () => true;
-    const description = "custom description";
+  it('Should accept a custom log description', () => {
+    const checkFunction = () => true
+    const description = 'custom description'
 
     const logger = {
-      log: (...params) => Cypress.log(...params)
-    };
-    const spy = cy.spy(logger, "log");
+      log: (...params) => Cypress.log(...params),
+    }
+    const spy = cy.spy(logger, 'log')
 
     cy.waitUntil(checkFunction, { logger: logger.log, description }).then(() => {
-      expect(spy).to.have.been.called;
-      const lastCallArgs = spy.lastCall.args[0];
-      expect(lastCallArgs).deep.include({ name: description });
-    });
-  });
+      expect(spy).to.have.been.called
+      const lastCallArgs = spy.lastCall.args[0]
+      expect(lastCallArgs).deep.include({ name: description })
+    })
+  })
 
-  it("Should accept a custom message", () => {
-    const checkFunction = () => true;
-    const customMessage = "custom message";
+  it('Should accept a custom message', () => {
+    const checkFunction = () => true
+    const customMessage = 'custom message'
 
     const logger = {
-      log: (...params) => Cypress.log(...params)
-    };
-    const spy = cy.spy(logger, "log");
-    const options = { logger: logger.log, customMessage };
+      log: (...params) => Cypress.log(...params),
+    }
+    const spy = cy.spy(logger, 'log')
+    const options = { logger: logger.log, customMessage }
 
     cy.waitUntil(checkFunction, options).then(() => {
-      expect(spy).to.have.been.called;
-      const lastCallArgs = spy.lastCall.args[0];
-      expect(lastCallArgs.message).deep.include(customMessage);
-    });
-  });
+      expect(spy).to.have.been.called
+      const lastCallArgs = spy.lastCall.args[0]
+      expect(lastCallArgs.message).deep.include(customMessage)
+    })
+  })
 
-  it("Should allow to turn off logging", () => {
-    const checkFunction = () => true;
+  it('Should allow to turn off logging', () => {
+    const checkFunction = () => true
 
     const logger = {
-      log: (...params) => Cypress.log(...params)
-    };
-    const spy = cy.spy(logger, "log");
+      log: (...params) => Cypress.log(...params),
+    }
+    const spy = cy.spy(logger, 'log')
 
     cy.waitUntil(checkFunction, { logger: logger.log, log: false }).then(() => {
-      expect(spy).not.to.have.been.called;
-    });
-  });
+      expect(spy).not.to.have.been.called
+    })
+  })
 
-  it("Should log verbosely every single check", () => {
-    let checks = 0;
+  it('Should log verbosely every single check', () => {
+    let checks = 0
     const checkFunction = () => {
-      checks++;
-      return checks > 1;
-    };
+      checks++
+      return checks > 1
+    }
 
     const logger = {
-      log: (...params) => Cypress.log(...params)
-    };
-    const spy = cy.spy(logger, "log");
-    const options = { logger: logger.log, verbose: true };
+      log: (...params) => Cypress.log(...params),
+    }
+    const spy = cy.spy(logger, 'log')
+    const options = { logger: logger.log, verbose: true }
 
     cy.waitUntil(checkFunction, options).then(() => {
-      const calls = spy.getCalls();
+      const calls = spy.getCalls()
       const expected = [
         {
-          name: "waitUntil"
+          name: 'waitUntil',
         },
         {
-          name: "waitUntil",
-          message: "false"
+          name: 'waitUntil',
+          message: 'false',
         },
         {
-          name: "waitUntil",
-          message: "true"
-        }
-      ];
-      expect(calls).to.have.lengthOf(expected.length);
+          name: 'waitUntil',
+          message: 'true',
+        },
+      ]
+      expect(calls).to.have.lengthOf(expected.length)
       for (let n = calls.length, i = 0; i < n; i++) {
-        expect(calls[i].args[0]).deep.include(expected[i]);
+        expect(calls[i].args[0]).deep.include(expected[i])
       }
-    });
-  });
+    })
+  })
 
-  it("Should accept a `customCheckMessage` option", () => {
-    const checkFunction = () => true;
+  it('Should accept a `customCheckMessage` option', () => {
+    const checkFunction = () => true
 
     const logger = {
-      log: (...params) => Cypress.log(...params)
-    };
-    const spy = cy.spy(logger, "log");
-    const customCheckMessage = "custom message check";
-    const options = { logger: logger.log, verbose: true, customCheckMessage };
+      log: (...params) => Cypress.log(...params),
+    }
+    const spy = cy.spy(logger, 'log')
+    const customCheckMessage = 'custom message check'
+    const options = { logger: logger.log, verbose: true, customCheckMessage }
 
     cy.waitUntil(checkFunction, options).then(() => {
-      expect(spy.getCalls()[1].args[0].message.toString()).to.include(customCheckMessage);
-    });
-  });
+      expect(spy.getCalls()[1].args[0].message.toString()).to.include(customCheckMessage)
+    })
+  })
 
   // test useful just to printout all the available options, screenshot them, and add them to the README
-  it("Options explanation", () => {
-    let checks = 0;
+  it('Options explanation', () => {
+    let checks = 0
     const checkFunction = () => {
-      checks++;
-      return checks > 2;
-    };
+      checks++
+      return checks > 2
+    }
     const checkFunction2 = () => {
-      checks++;
-      return checks > 5;
-    };
+      checks++
+      return checks > 5
+    }
 
     const options = {
       // log options
-      description: "description",
-      customMessage: "customMessage",
+      description: 'description',
+      customMessage: 'customMessage',
       verbose: true,
-      customCheckMessage: "customCheckMessage"
-    };
+      customCheckMessage: 'customCheckMessage',
+    }
 
-    cy.waitUntil(checkFunction, { verbose: true });
-    cy.waitUntil(checkFunction2, options);
-  });
-});
+    cy.waitUntil(checkFunction, { verbose: true })
+    cy.waitUntil(checkFunction2, options)
+  })
+})

--- a/cypress/types/plugin.spec.ts
+++ b/cypress/types/plugin.spec.ts
@@ -16,6 +16,21 @@ cy.waitUntil(() => true, { errorMsg: () => 'Custom error message' })
 cy.waitUntil(() => Promise.resolve(true), {
   errorMsg: () => 'Custom error message',
 })
+cy.waitUntil(() => Promise.resolve(true), {
+  errorMsg: () => 'Custom error message',
+})
+cy.waitUntil(() => true, {
+  errorMsg: (
+    _result: any,
+    {
+      timeout,
+      interval,
+    }: {
+      timeout: number
+      interval: number
+    }
+  ) => 'Custom error message',
+})
 
 cy.waitUntil(() => true, { description: 'Custom description' })
 
@@ -41,6 +56,18 @@ cy.waitUntil<boolean>(() => Promise.resolve(true), { errorMsg: 'Custom error mes
 cy.waitUntil<boolean>(() => true, { errorMsg: () => 'Custom error message' })
 cy.waitUntil<boolean>(() => Promise.resolve(true), {
   errorMsg: () => 'Custom error message',
+})
+cy.waitUntil<boolean>(() => true, {
+  errorMsg: (
+    _result: boolean,
+    {
+      timeout,
+      interval,
+    }: {
+      timeout: number
+      interval: number
+    }
+  ) => 'Custom error message',
 })
 cy.waitUntil<boolean>(() => true, { description: 'Custom description' })
 cy.waitUntil<boolean>(() => true, {

--- a/cypress/types/plugin.spec.ts
+++ b/cypress/types/plugin.spec.ts
@@ -1,43 +1,52 @@
 /// <reference types="Cypress" />
 
-cy.waitUntil(() => true);
-cy.waitUntil(() => false);
-cy.waitUntil(() => Promise.resolve(true));
-cy.waitUntil(() => Promise.resolve(false));
+cy.waitUntil(() => true)
+cy.waitUntil(() => Promise.resolve(true))
 
-cy.waitUntil(() => true, {});
-cy.waitUntil(() => false, {});
-cy.waitUntil(() => Promise.resolve(true), {});
-cy.waitUntil(() => Promise.resolve(false), {});
+cy.waitUntil(() => true, {})
+cy.waitUntil(() => Promise.resolve(true), {})
 
-cy.waitUntil(() => true, { timeout: 500 });
-cy.waitUntil(() => false, { timeout: 500 });
-cy.waitUntil(() => Promise.resolve(true), { timeout: 500 });
-cy.waitUntil(() => Promise.resolve(false), { timeout: 500 });
+cy.waitUntil(() => true, { timeout: 500 })
+cy.waitUntil(() => Promise.resolve(true), { timeout: 500 })
 
-cy.waitUntil(() => true, { errorMsg: "Custom error message" });
-cy.waitUntil(() => false, { errorMsg: "Custom error message" });
-cy.waitUntil(() => Promise.resolve(true), { errorMsg: "Custom error message" });
-cy.waitUntil(() => Promise.resolve(false), {
-  errorMsg: "Custom error message",
-});
+cy.waitUntil(() => true, { errorMsg: 'Custom error message' })
+cy.waitUntil(() => Promise.resolve(true), { errorMsg: 'Custom error message' })
 
-cy.waitUntil(() => true, { errorMsg: () => "Custom error message" });
-cy.waitUntil(() => false, { errorMsg: () => "Custom error message" });
+cy.waitUntil(() => true, { errorMsg: () => 'Custom error message' })
 cy.waitUntil(() => Promise.resolve(true), {
-  errorMsg: () => "Custom error message",
-});
-cy.waitUntil(() => Promise.resolve(false), {
-  errorMsg: () => "Custom error message",
-});
+  errorMsg: () => 'Custom error message',
+})
 
-cy.waitUntil(() => true, { description: "Custom description" });
+cy.waitUntil(() => true, { description: 'Custom description' })
 
 cy.waitUntil(() => true, {
   logger: ({ name, message, consoleProps }) => {
-    console.log({ name, message, consoleProps });
-  }
-});
+    console.log({ name, message, consoleProps })
+  },
+})
 
-cy.waitUntil(() => true, { log: false });
-cy.waitUntil(() => true, { customMessage: "custom message" });
+cy.waitUntil(() => true, { log: false })
+cy.waitUntil(() => true, { customMessage: 'custom message' })
+
+// below there are the same tests but leveraging the TS Generic
+
+cy.waitUntil<boolean>(() => true)
+cy.waitUntil<boolean>(() => Promise.resolve(true))
+cy.waitUntil<boolean>(() => true, {})
+cy.waitUntil<boolean>(() => Promise.resolve(true), {})
+cy.waitUntil<boolean>(() => true, { timeout: 500 })
+cy.waitUntil<boolean>(() => Promise.resolve(true), { timeout: 500 })
+cy.waitUntil<boolean>(() => true, { errorMsg: 'Custom error message' })
+cy.waitUntil<boolean>(() => Promise.resolve(true), { errorMsg: 'Custom error message' })
+cy.waitUntil<boolean>(() => true, { errorMsg: () => 'Custom error message' })
+cy.waitUntil<boolean>(() => Promise.resolve(true), {
+  errorMsg: () => 'Custom error message',
+})
+cy.waitUntil<boolean>(() => true, { description: 'Custom description' })
+cy.waitUntil<boolean>(() => true, {
+  logger: ({ name, message, consoleProps }) => {
+    console.log({ name, message, consoleProps })
+  },
+})
+cy.waitUntil<boolean>(() => true, { log: false })
+cy.waitUntil<boolean>(() => true, { customMessage: 'custom message' })

--- a/cypress/types/plugin.spec.ts
+++ b/cypress/types/plugin.spec.ts
@@ -18,7 +18,18 @@ cy.waitUntil(() => Promise.resolve(false), { timeout: 500 });
 cy.waitUntil(() => true, { errorMsg: "Custom error message" });
 cy.waitUntil(() => false, { errorMsg: "Custom error message" });
 cy.waitUntil(() => Promise.resolve(true), { errorMsg: "Custom error message" });
-cy.waitUntil(() => Promise.resolve(false), { errorMsg: "Custom error message" });
+cy.waitUntil(() => Promise.resolve(false), {
+  errorMsg: "Custom error message",
+});
+
+cy.waitUntil(() => true, { errorMsg: () => "Custom error message" });
+cy.waitUntil(() => false, { errorMsg: () => "Custom error message" });
+cy.waitUntil(() => Promise.resolve(true), {
+  errorMsg: () => "Custom error message",
+});
+cy.waitUntil(() => Promise.resolve(false), {
+  errorMsg: () => "Custom error message",
+});
 
 cy.waitUntil(() => true, { description: "Custom description" });
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,11 +1,16 @@
 /// <reference types="Cypress" />
 
-type WaitUntilLog = Pick<Cypress.LogConfig, "name" | "message" | "consoleProps">;
+type WaitUntilLog = Pick<
+  Cypress.LogConfig,
+  "name" | "message" | "consoleProps"
+>;
+
+type ErrorMsgCallback = (result: any, options: any) => string;
 
 interface WaitUntilOptions {
   timeout?: number;
   interval?: number;
-  errorMsg?: string;
+  errorMsg?: string | ErrorMsgCallback;
   description?: string;
   customMessage?: string;
   verbose?: boolean;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,29 +1,29 @@
 /// <reference types="Cypress" />
 
-type WaitUntilLog = Pick<
-  Cypress.LogConfig,
-  "name" | "message" | "consoleProps"
->;
+type WaitUntilLog = Pick<Cypress.LogConfig, 'name' | 'message' | 'consoleProps'>
 
-type ErrorMsgCallback = (result: any, options: any) => string;
+type ErrorMsgCallback<Subject = any> = (
+  result: Subject,
+  options: WaitUntilOptions<Subject>
+) => string
 
-interface WaitUntilOptions {
-  timeout?: number;
-  interval?: number;
-  errorMsg?: string | ErrorMsgCallback;
-  description?: string;
-  customMessage?: string;
-  verbose?: boolean;
-  customCheckMessage?: string;
-  logger?: (logOptions: WaitUntilLog) => any;
-  log?: boolean;
+interface WaitUntilOptions<Subject = any> {
+  timeout?: number
+  interval?: number
+  errorMsg?: string | ErrorMsgCallback<Subject>
+  description?: string
+  customMessage?: string
+  verbose?: boolean
+  customCheckMessage?: string
+  logger?: (logOptions: WaitUntilLog) => any
+  log?: boolean
 }
 
 declare namespace Cypress {
   interface Chainable<Subject = any> {
     waitUntil<Subject>(
       checkFunction: () => Subject | Chainable<Subject> | Promise<Subject>,
-      options?: WaitUntilOptions
-    ): Chainable<Subject>;
+      options?: WaitUntilOptions<Subject>
+    ): Chainable<Subject>
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -57,7 +57,8 @@ const waitUntil = (subject, checkFunction, originalOptions = {}) => {
       return result;
     }
     if (retries < 1) {
-      throw new Error(options.errorMsg);
+      const msg = options.errorMsg.call ? options.errorMsg() : options.errorMsg;
+      throw new Error(msg);
     }
     cy.wait(options.interval, { log: false }).then(() => {
       retries--;

--- a/src/index.js
+++ b/src/index.js
@@ -5,7 +5,7 @@ const logCommand = ({ options, originalOptions }) => {
     options.logger({
       name: options.description,
       message: options.customMessage,
-      consoleProps: () => originalOptions
+      consoleProps: () => originalOptions,
     });
   }
 };
@@ -19,13 +19,15 @@ const logCommandCheck = ({ result, options, originalOptions }) => {
   options.logger({
     name: options.description,
     message,
-    consoleProps: () => originalOptions
+    consoleProps: () => originalOptions,
   });
 };
 
 const waitUntil = (subject, checkFunction, originalOptions = {}) => {
   if (!(checkFunction instanceof Function)) {
-    throw new Error("`checkFunction` parameter should be a function. Found: " + checkFunction);
+    throw new Error(
+      "`checkFunction` parameter should be a function. Found: " + checkFunction
+    );
   }
 
   const defaultOptions = {
@@ -40,24 +42,29 @@ const waitUntil = (subject, checkFunction, originalOptions = {}) => {
     customMessage: undefined,
     logger: Cypress.log,
     verbose: false,
-    customCheckMessage: undefined
+    customCheckMessage: undefined,
   };
   const options = { ...defaultOptions, ...originalOptions };
 
   // filter out a falsy passed "customMessage" value
-  options.customMessage = [options.customMessage, originalOptions].filter(Boolean);
+  options.customMessage = [options.customMessage, originalOptions].filter(
+    Boolean
+  );
 
   let retries = Math.floor(options.timeout / options.interval);
 
   logCommand({ options, originalOptions });
 
-  const check = result => {
+  const check = (result) => {
     logCommandCheck({ result, options, originalOptions });
     if (result) {
       return result;
     }
     if (retries < 1) {
-      const msg = options.errorMsg.call ? options.errorMsg() : options.errorMsg;
+      const msg =
+        options.errorMsg instanceof Function
+          ? options.errorMsg(result, options)
+          : options.errorMsg;
       throw new Error(msg);
     }
     cy.wait(options.interval, { log: false }).then(() => {

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-"use strict";
+'use strict'
 
 const logCommand = ({ options, originalOptions }) => {
   if (options.log) {
@@ -6,85 +6,79 @@ const logCommand = ({ options, originalOptions }) => {
       name: options.description,
       message: options.customMessage,
       consoleProps: () => originalOptions,
-    });
+    })
   }
-};
+}
 const logCommandCheck = ({ result, options, originalOptions }) => {
-  if (!options.log || !options.verbose) return;
+  if (!options.log || !options.verbose) return
 
-  const message = [result];
+  const message = [result]
   if (options.customCheckMessage) {
-    message.unshift(options.customCheckMessage);
+    message.unshift(options.customCheckMessage)
   }
   options.logger({
     name: options.description,
     message,
     consoleProps: () => originalOptions,
-  });
-};
+  })
+}
 
 const waitUntil = (subject, checkFunction, originalOptions = {}) => {
   if (!(checkFunction instanceof Function)) {
-    throw new Error(
-      "`checkFunction` parameter should be a function. Found: " + checkFunction
-    );
+    throw new Error('`checkFunction` parameter should be a function. Found: ' + checkFunction)
   }
 
   const defaultOptions = {
     // base options
     interval: 200,
     timeout: 5000,
-    errorMsg: "Timed out retrying",
+    errorMsg: 'Timed out retrying',
 
     // log options
-    description: "waitUntil",
+    description: 'waitUntil',
     log: true,
     customMessage: undefined,
     logger: Cypress.log,
     verbose: false,
     customCheckMessage: undefined,
-  };
-  const options = { ...defaultOptions, ...originalOptions };
+  }
+  const options = { ...defaultOptions, ...originalOptions }
 
   // filter out a falsy passed "customMessage" value
-  options.customMessage = [options.customMessage, originalOptions].filter(
-    Boolean
-  );
+  options.customMessage = [options.customMessage, originalOptions].filter(Boolean)
 
-  let retries = Math.floor(options.timeout / options.interval);
+  let retries = Math.floor(options.timeout / options.interval)
 
-  logCommand({ options, originalOptions });
+  logCommand({ options, originalOptions })
 
   const check = (result) => {
-    logCommandCheck({ result, options, originalOptions });
+    logCommandCheck({ result, options, originalOptions })
     if (result) {
-      return result;
+      return result
     }
     if (retries < 1) {
       const msg =
-        options.errorMsg instanceof Function
-          ? options.errorMsg(result, options)
-          : options.errorMsg;
-      throw new Error(msg);
+        options.errorMsg instanceof Function ? options.errorMsg(result, options) : options.errorMsg
+      throw new Error(msg)
     }
     cy.wait(options.interval, { log: false }).then(() => {
-      retries--;
-      return resolveValue();
-    });
-  };
+      retries--
+      return resolveValue()
+    })
+  }
 
   const resolveValue = () => {
-    const result = checkFunction(subject);
+    const result = checkFunction(subject)
 
-    const isAPromise = Boolean(result && result.then);
+    const isAPromise = Boolean(result && result.then)
     if (isAPromise) {
-      return result.then(check);
+      return result.then(check)
     } else {
-      return check(result);
+      return check(result)
     }
-  };
+  }
 
-  return resolveValue();
-};
+  return resolveValue()
+}
 
-Cypress.Commands.add("waitUntil", { prevSubject: "optional" }, waitUntil);
+Cypress.Commands.add('waitUntil', { prevSubject: 'optional' }, waitUntil)


### PR DESCRIPTION
This allows the error message to be evaluated at the time of failure (instead of at call time), so it can potentially include details that may differ from when `waitUntil` was first called. Specifically, this lets you include more detailed information in the error message about what exactly failed.