### PR TITLE
Changing the timeout logic. 

### DIFF
--- a/cypress/e2e/plugin.spec.js
+++ b/cypress/e2e/plugin.spec.js
@@ -39,6 +39,38 @@ context('Cypress Wait Until', () => {
     })
   })
 
+  it('Should run once if waitUntil timeout is less than checkFunction execution time', () => {
+    let checks = 0
+    const checkFunction = () => {
+      cy.wait(500).then(() => {
+        checks++
+        return false
+      })
+    }
+
+    cy.once('fail', () => {
+      expect(checks).to.equal(1)
+    })
+
+    cy.waitUntil(checkFunction, { timeout: 400 })
+  })
+
+  it('Should run 3 times if checkFunction + interval is 2s and timeout is 5s', () => {
+    let checks = 0
+    const checkFunction = () => {
+      cy.wait(1500).then(() => {
+        checks++
+        return false
+      })
+    }
+
+    cy.once('fail', () => {
+      expect(checks).to.equal(3)
+    })
+
+    cy.waitUntil(checkFunction, { timeout: 5000, interval: 500 })
+  })
+
   it('Should apply options correctly', () => {
     const COOKIE_NAME = 'after-a-while-cookie'
     const EXPECTED_COOKIE_VALUE = 'Set'

--- a/src/index.js
+++ b/src/index.js
@@ -47,7 +47,7 @@ const waitUntil = (subject, checkFunction, originalOptions = {}) => {
   // filter out a falsy passed "customMessage" value
   options.customMessage = [options.customMessage, originalOptions].filter(Boolean)
 
-  let retries = Math.floor(options.timeout / options.interval)
+  const endTime = Date.now() + options.timeout
 
   logCommand({ options, originalOptions })
 
@@ -56,13 +56,12 @@ const waitUntil = (subject, checkFunction, originalOptions = {}) => {
     if (result) {
       return result
     }
-    if (retries < 1) {
+    if (Date.now() >= endTime) {
       const msg =
         options.errorMsg instanceof Function ? options.errorMsg(result, options) : options.errorMsg
       throw new Error(msg)
     }
     cy.wait(options.interval, { log: false }).then(() => {
-      retries--
       return resolveValue()
     })
   }


### PR DESCRIPTION
[Resolves issue #464](https://github.com/NoriSte/cypress-wait-until/issues/464)

By moving away from a retry countdown and instead using a timestamp comparison on each iteration, `waitUntil()` should timeout closer to the user-defined timeout.