### PR TITLE
chore(deps): Revert: Set the Node and NPM version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cypress-wait-until",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cypress-wait-until",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "license": "MIT",
       "devDependencies": {
         "@semantic-release/npm": "10.0.3",

--- a/package.json
+++ b/package.json
@@ -1,12 +1,8 @@
 {
   "name": "cypress-wait-until",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "A waiting plugin for Cypress",
   "main": "src/index.js",
-  "engines": {
-    "node": ">=18.16.0",
-    "npm": ">=9.5.1"
-  },
   "dependencies": {},
   "devDependencies": {
     "cypress": "12.13.0",


### PR DESCRIPTION
Fix #472 

@NoriSte I couldn't do a clean revert of 70536802db039175435a01d7aa99ff7acf9b00e4 because of the package-lock changes, so I'm just removing what was added and updating the lock file with a patch version.