### PR TITLE
Fix typescript signature

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - 10
+  - 20
 addons:
   apt:
     packages:

--- a/cypress/types/plugin.spec.ts
+++ b/cypress/types/plugin.spec.ts
@@ -82,3 +82,7 @@ cy.wrap('').waitUntil((subject) => subject.length)
 cy.wrap('').waitUntil<boolean>((subject) => !!subject.length)
 cy.wrap<string>('').waitUntil<boolean>((subject) => !!subject.length)
 cy.wrap<string>('').waitUntil((subject) => subject.length)
+
+cy.waitUntil(() => cy.task<number>('myTaskReturningANumber')).then((subject) => {
+  subject * subject
+})

--- a/index.d.ts
+++ b/index.d.ts
@@ -26,6 +26,6 @@ declare namespace Cypress {
         subject: Subject | undefined
       ) => ReturnType | Chainable<ReturnType> | Promise<ReturnType>,
       options?: WaitUntilOptions<Subject>
-    ): Chainable<Subject>
+    ): Chainable<ReturnType>
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,10 @@
         "serve": "14.2.0",
         "start-server-and-test": "2.0.0",
         "typescript": "5.0.4"
+      },
+      "engines": {
+        "node": ">=20.1.0",
+        "npm": ">=9.6.4"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,10 @@
 {
   "name": "cypress-wait-until",
   "version": "2.0.1",
+  "engines" : {
+    "npm" : ">=9.6.4",
+    "node" : ">=20.1.0"
+  },
   "description": "A waiting plugin for Cypress",
   "main": "src/index.js",
   "dependencies": {},


### PR DESCRIPTION
Fix #477.

Please note that: TypeScript tests could now throw because of operations made on the value returned by `checkFunction` (passed to cy.waitUntil). The type was previously `undefined` while now reflecting the type returned by `checkFunction`.